### PR TITLE
Set default build source encoding to UTF-8

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -17,6 +17,7 @@
         <finalName>${artifactId}</finalName>
     </build>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>


### PR DESCRIPTION
For those of us stil using Windows, it will make sense to have the default source encoding set to UTF-8.