### PR TITLE
Put JAXRSConfiguration.java in package path.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <groupId>com.airhacks</groupId>
     <artifactId>javaee7-essentials-archetype</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.3.1</version>
     <name>javaee7-essentials-archetype</name>
     <description>Java EE 7 project template. Clean, lean and minimalistic.</description>
     <url>http://airhacks.com</url>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -17,6 +17,7 @@
         <finalName>${artifactId}</finalName>
     </build>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/JAXRSConfiguration.java
+++ b/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/JAXRSConfiguration.java
@@ -1,4 +1,4 @@
-package com.airhacks;
+package ${package};
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;


### PR DESCRIPTION
When running the archetype the package entered seems to be ignored and the file JAXRSConfiguration.java always ends up in package com.airhacks and directory-path com/airhacks instead of the expected package and directory-path. This fixes that issue.

Also, added UTF-8 to pom.xml to get rid of warnings.
Slight increase in version number.